### PR TITLE
Support special 'append' prefix for category

### DIFF
--- a/lib/MooseX/Log/Log4perl.pm
+++ b/lib/MooseX/Log/Log4perl.pm
@@ -16,8 +16,8 @@ has 'logger' => (
 sub log {
     my $self = shift;
     my $cat = shift;
-    if ($cat && $cat =~ m/^\+(.*)/) {
-        return Log::Log4perl->get_logger(ref($self) . "::" . $1);
+    if ($cat && $cat =~ m/^(\.|::)/) {
+        return Log::Log4perl->get_logger(ref($self) . $cat);
     } elsif($cat)  {
         return Log::Log4perl->get_logger($cat);
     } else {
@@ -46,7 +46,8 @@ MooseX::Log::Log4perl - A Logging Role for Moose based on Log::Log4perl
         ...
         $self->log('special')->info('bar');  ### logs with category "special"
         ...
-        $self->log('+special')->info('bar'); ### logs with category "MyApp.special"
+        $self->log('.special')->info('bar'); ### logs with category "MyApp.special"
+        $self->log('::special')->info('bar');### logs with category "MyApp.special"
     }
 
 =head1 DESCRIPTION
@@ -148,7 +149,8 @@ class (what would have been the category if you didn't specify one).
  }
  $myapp->log("TempCat")->info("Foobar"); # category TempCat
  $myapp->log->info("Grumble"); # category class again myapp
- $myapp->log("+TempCat")->info("Foobar"); # category myapp.TempCat
+ $myapp->log(".TempCat")->info("Foobar"); # category myapp.TempCat
+ $myapp->log("::TempCat")->info("Foobar"); # category myapp.TempCat
 
 =head1 SEE ALSO
 

--- a/t/01basic.t
+++ b/t/01basic.t
@@ -31,7 +31,8 @@ __ENDCFG__
 		$self->log->trace('hey');
 		$self->log->debug('foo');
 		$self->log("SPECIAL")->info('BAZ');
-		$self->log("+SPECIAL")->info('BAZ');
+		$self->log(".SPECIAL")->info('BAZ');
+		$self->log("::SPECIAL")->info('BAZ');
 		$self->log->warn('no nooo NOOOO');
 		$self->log->error('bar');
 		$self->log->fatal('titanic is sinking');
@@ -76,6 +77,7 @@ __ENDCFG__
 TRACE [BasicLogTest] [BasicLogTest::test_log] hey
 DEBUG [BasicLogTest] [BasicLogTest::test_log] foo
 INFO [SPECIAL] [BasicLogTest::test_log] BAZ
+INFO [BasicLogTest.SPECIAL] [BasicLogTest::test_log] BAZ
 INFO [BasicLogTest.SPECIAL] [BasicLogTest::test_log] BAZ
 WARN [BasicLogTest] [BasicLogTest::test_log] no nooo NOOOO
 ERROR [BasicLogTest] [BasicLogTest::test_log] bar


### PR DESCRIPTION
Hey

I have some rather large classes I want to convert to log4perl-logging, but I would love to be able to specify my category a bit finer grained than class, while still not have to specify the whole class all over the place, so I came up with this idea.

I am not too familiar with log4perl, so I don't know if the + is a good choice for a "concat" operator here or not, or if just checking if it starts with '.' or '::' instead would perhaps make more sense.

What do you think of such a feature?
