### PR TITLE
Tests converted to use Moo instead of Moose

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -23,7 +23,7 @@ __ENDCFG__
 {
 	package BasicLogTest;
 
-	use Moose;
+	use Moo;
 	with 'MooseX::Log::Log4perl';
 
 	sub test_log {
@@ -42,10 +42,10 @@ __ENDCFG__
 {
 	package BasicLogTest;
 
-	use Moose;
+	use Moo;
 	with 'MooseX::Log::Log4perl';
 
-	has 'foo' => ( is => 'rw', isa => 'Str' );
+	has 'foo' => ( is => 'rw' );
 }
 
 {

--- a/t/02easy.t
+++ b/t/02easy.t
@@ -23,7 +23,7 @@ __ENDCFG__
 {
 	package EasyLogTest;
 
-	use Moose;
+	use Moo;
 	with 'MooseX::Log::Log4perl::Easy';
 
 	sub test_easy {

--- a/t/03inheritance.t
+++ b/t/03inheritance.t
@@ -21,7 +21,7 @@ __ENDCFG__
 {
 	package Parent;
 
-	use Moose;
+	use Moo;
 	with 'MooseX::Log::Log4perl';
 
 	sub overridden { shift->log->warn('Parent overridden');	}
@@ -31,7 +31,7 @@ __ENDCFG__
 {
 	package Child;
 
-	use Moose;
+	use Moo;
 	extends 'Parent';
 	with 'MooseX::Log::Log4perl';
 

--- a/t/99bench.t
+++ b/t/99bench.t
@@ -29,7 +29,7 @@ END {
 {
 	package BenchMooseXLogLog4perl;
 
-	use Moose;
+	use Moo;
 	with 'MooseX::Log::Log4perl';
 
 	sub testlog { shift->log->info("Just a test for logging"); }


### PR DESCRIPTION
Having been assigned MooseX-Log-Log4perl as part of the [CPAN PR Challenge](http://cpan-prc.org) I saw that it had recently been changed to use Moo instead of (the recently-deprecated) Any::Moose. However, when I tried to build the version from the repo the tests would fail because they depended on Moose (which I didn't have installed) and which was not listed as a dependency in the dist.

So, I've simply gone through the tests and replaced the use of Moose with Moo instead and they seem to work for me. The only exception is the author test at t/99bench.t which narrowly failed a couple of subtests on the thresholds. I've nothing to compare this with so it is your call whether that's a significant problem or not - they may well pass on your test platform after all. Here are the failures I received:

```
#   Failed test 'Call rate of ->log must be above 94% (33325 / 34528 = 92.93 %) to Log4perl direct'
#   at t/99bench.t line 94.

#   Failed test 'Call rate of ->log must be above 95% (33325 / 34296 = 93.56 %) to Log4perl via method'
#   at t/99bench.t line 101.
# Looks like you failed 2 tests of 6.
```

I hope that these changes are useful, if rather trivial. If there's anything else in the dist which you think might benefit from some attention, please feel free to suggest.