### PR TITLE
MooseX::Log::Log4perl::Easy botches localising l4p's $caller_depth

### DIFF
--- a/lib/MooseX/Log/Log4perl/Easy.pm
+++ b/lib/MooseX/Log/Log4perl/Easy.pm
@@ -6,12 +6,12 @@ with 'MooseX::Log::Log4perl';
 
 our $VERSION = '0.47';
 
-sub log_fatal { local $Log::Log4perl::caller_depth += 1; return shift->logger->fatal(@_); }
-sub log_error { local $Log::Log4perl::caller_depth += 1; return shift->logger->error(@_); }
-sub log_warn  { local $Log::Log4perl::caller_depth += 1; return shift->logger->warn(@_); }
-sub log_info  { local $Log::Log4perl::caller_depth += 1; return shift->logger->info(@_); }
-sub log_debug { local $Log::Log4perl::caller_depth += 1; return shift->logger->debug(@_); }
-sub log_trace { local $Log::Log4perl::caller_depth += 1; return shift->logger->trace(@_); }
+sub log_fatal { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->fatal(@_); }
+sub log_error { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->error(@_); }
+sub log_warn  { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->warn(@_); }
+sub log_info  { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->info(@_); }
+sub log_debug { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->debug(@_); }
+sub log_trace { local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1; return shift->logger->trace(@_); }
 
 1;
 

--- a/t/04caller_depth.t
+++ b/t/04caller_depth.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test::More;
+use IO::Scalar;
+use Log::Log4perl;
+
+# local, it's not what you think:
+#   perl -E 'sub rofl { say $a }; sub lol { local $a += 1; rofl  }; our $a = 12 ; lol() '
+{
+	Log::Log4perl->init( \q{
+log4perl.rootLogger = TRACE, Test
+
+log4perl.appender.Test        = Log::Log4perl::Appender::String
+log4perl.appender.Test.stderr = 1
+log4perl.appender.Test.layout = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.Test.layout.ConversionPattern = calling=<%l> caller_line=<%L> - %m
+});
+
+
+    my $log = I::Log->new;
+    $log->log_should_be_invisible('called from main');
+
+    my $messages= $Log::Log4perl::Logger::APPENDER_BY_NAME{Test}->string;
+    unlike( $messages, qr{I::Log::log_should_be_invisible}, "We shouldn't see log_should_be_invisible in the log entry") or diag "unexpected log: $messages";
+    like($messages, qr{called from main}, "our message made it through");
+    like($messages, qr{\QYou shouldn't see me as the caller!}, "log_should_be_invisible's message should be in the log");
+}
+
+
+BEGIN {
+# line 1 "I/Log.pm"
+    package I::Log {
+        use Moo;
+        with 'MooseX::Log::Log4perl::Easy';
+
+        sub log_should_be_invisible {
+            my $self = shift;
+            local $Log::Log4perl::caller_depth
+                = $Log::Log4perl::caller_depth + 1;
+
+            $self->log_info("You shouldn't see me as the caller!: @_")
+        }
+
+    }
+}
+
+done_testing;


### PR DESCRIPTION
If I try to hide one of my subs from logging by adding a:
```perl
 local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth  + 1;
```
before my call to `log_*`, the `local`s in `sub log_*` will overwrite my value of `$caller_depth` with `1`, and my sub appears in `%l` and friends. 

This happens because the `log_*` subs don't `local`ise `$caller_depth` correctly. 

As a side note, the docs suggest that `#moose` is a good place to look for _the author_, and that seems to no longer be the case.